### PR TITLE
fix: config variables resolution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,6 @@ class NewRelicPlugin implements Plugin {
 
   constructor(serverless: Serverless) {
     this.serverless = serverless
-    this.awsProvider = this.serverless.getProvider('aws')
-    this.serviceName = `${getNormalizedName(this.serverless.service.getServiceName())} ${upperCase(
-      this.awsProvider.getStage()
-    )}`
-    this.policyName = getNormalizedPolicyName(this.serviceName)
 
     if (this.serverless.service.custom && this.serverless.service.custom.newrelic) {
       const {
@@ -269,7 +264,17 @@ class NewRelicPlugin implements Plugin {
     return globalAlerts
   }
 
+  configure() {
+    // access to the configuration vars should be done only in the hooks, as it may not be resolved earlier
+    this.awsProvider = this.serverless.getProvider('aws')
+    this.serviceName = `${getNormalizedName(this.serverless.service.getServiceName())} ${upperCase(
+      this.awsProvider.getStage()
+    )}`
+    this.policyName = getNormalizedPolicyName(this.serviceName)
+  }
+
   compile() {
+    this.configure()
     Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
       ...this.getPolicyCloudFormation(
         this.serverless.service.custom.newrelic.incidentPreference || 'PER_POLICY'

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -69,6 +69,7 @@ describe('Newrelic Alert Plugin', () => {
   describe('getPolicyCloudFormation', () => {
     it('should generate valid policy', () => {
       const plugin = new NewRelicPlugin(getServerless(minimalConfig))
+      plugin.configure()
       const policy = plugin.getPolicyCloudFormation()
       expect(policy).toMatchSnapshot()
     })
@@ -77,7 +78,7 @@ describe('Newrelic Alert Plugin', () => {
   describe('getInfrastructureConditionCloudFormation', () => {
     it('should throw error with invalid infrastructure conditions', () => {
       const plugin = new NewRelicPlugin(getServerless(minimalConfig))
-
+      plugin.configure()
       try {
         const infrastructureCondition = plugin.getInfrastructureConditionCloudFormation(
           FunctionAlert.THROTTLES,
@@ -111,6 +112,8 @@ describe('Newrelic Alert Plugin', () => {
           }
         )
       )
+
+      plugin.configure()
       const cf = plugin.getFunctionAlertsCloudFormation()
       expect(cf).toMatchSnapshot()
     })
@@ -136,6 +139,8 @@ describe('Newrelic Alert Plugin', () => {
           }
         )
       )
+
+      plugin.configure()
       const cf = plugin.getFunctionAlertsCloudFormation()
       expect(cf).toMatchSnapshot()
     })
@@ -147,6 +152,8 @@ describe('Newrelic Alert Plugin', () => {
           alerts: [...Object.values(FunctionAlert), ...Object.values(ApiGatewayAlert)]
         })
       )
+
+      plugin.configure()
       const cf = plugin.getFunctionAlertsCloudFormation()
       expect(cf).toEqual({})
     })
@@ -168,6 +175,8 @@ describe('Newrelic Alert Plugin', () => {
           }
         )
       )
+
+      plugin.configure()
       const cf = plugin.getFunctionAlertsCloudFormation()
       expect(cf).toEqual({})
     })
@@ -199,6 +208,8 @@ describe('Newrelic Alert Plugin', () => {
           }
         )
       )
+
+      plugin.configure()
       const cf = plugin.getAlertsCloudFormation('AWS::ApiGateway::RestApi')
       expect(cf).toMatchSnapshot()
     })
@@ -210,6 +221,8 @@ describe('Newrelic Alert Plugin', () => {
           alerts: [...Object.values(FunctionAlert), ...Object.values(ApiGatewayAlert)]
         })
       )
+
+      plugin.configure()
       const cf = plugin.getAlertsCloudFormation('AWS::ApiGateway::RestApi')
       expect(cf).toEqual({})
     })
@@ -233,6 +246,8 @@ describe('Newrelic Alert Plugin', () => {
           }
         )
       )
+
+      plugin.configure()
       const cf = plugin.getAlertsCloudFormation('AWS::ApiGateway::RestApi')
       expect(cf).toEqual({})
     })
@@ -270,6 +285,8 @@ describe('Newrelic Alert Plugin', () => {
           }
         )
       )
+
+      plugin.configure()
       const cf = plugin.getAlertsCloudFormation('AWS::SQS::Queue')
       expect(cf).toMatchSnapshot()
     })
@@ -298,6 +315,8 @@ describe('Newrelic Alert Plugin', () => {
           }
         )
       )
+
+      plugin.configure()
       const cf = plugin.getAlertsCloudFormation('AWS::SQS::Queue')
       expect(cf).toEqual({})
     })
@@ -321,6 +340,8 @@ describe('Newrelic Alert Plugin', () => {
           }
         )
       )
+
+      plugin.configure()
       const cf = plugin.getAlertsCloudFormation('AWS::SQS::Queue')
       expect(cf).toEqual({})
     })
@@ -352,6 +373,8 @@ describe('Newrelic Alert Plugin', () => {
           }
         )
       )
+
+      plugin.configure()
       const cf = plugin.getAlertsCloudFormation('AWS::DynamoDB::Table')
       expect(cf).toMatchSnapshot()
     })
@@ -363,6 +386,8 @@ describe('Newrelic Alert Plugin', () => {
           alerts: [...Object.values(DynamoDbAlert), ...Object.values(ApiGatewayAlert)]
         })
       )
+
+      plugin.configure()
       const cf = plugin.getAlertsCloudFormation('AWS::DynamoDB::Table')
       expect(cf).toEqual({})
     })
@@ -386,6 +411,8 @@ describe('Newrelic Alert Plugin', () => {
           }
         )
       )
+
+      plugin.configure()
       const cf = plugin.getAlertsCloudFormation('AWS::DynamoDB::Table')
       expect(cf).toEqual({})
     })


### PR DESCRIPTION
Added the `configure` method for the plugin to gather all config variables, to solve the issue when a variable needs to be resolved i.e `var: ${self:foo.bar.${self:foo.baz}}`

According to the [SLS docs](https://www.serverless.com/framework/docs/providers/aws/guide/plugins#serverless-instance):

> Note: Variable references in the serverless instance are not resolved before a Plugin's constructor is called, so if you need these, make sure to wait to access those from your hooks.