### PR TITLE
Force Angular commit message format in Pull Request

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run: npm ci
       - run:
           name: Define environment variable with lastest commit's message
           command: |


### PR DESCRIPTION
## Description

semantic-release only deploys commit messages formatted per the Angular rules:
https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commi

## Checklist

<!-- Please delete options that are not relevant. Mark relevant option with [x] -->

- [x] Make sure latest commit follows https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit, so update can be released
